### PR TITLE
fix: chunk.Size excludes padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Resource Interchange File Format parser
 
-[![GoDoc](http://godoc.org/github.com/go-audio/riff?status.svg)](http://godoc.org/go-audio/riff)
+[![GoDoc](http://godoc.org/github.com/go-audio/riff?status.svg)](http://godoc.org/github.com/go-audio/riff)
 
 [![Build
 Status](https://travis-ci.org/go-audio/riff.png)](https://travis-ci.org/go-audio/riff)

--- a/parser.go
+++ b/parser.go
@@ -133,13 +133,6 @@ func (c *Parser) NextChunk() (*Chunk, error) {
 		return nil, err
 	}
 
-	// all RIFF chunks (including WAVE "data" chunks) must be word aligned.
-	// If the data uses an odd number of bytes, a padding byte with a value of zero must be placed at the end of the sample data.
-	// The "data" chunk header's size should not include this byte.
-	if size%2 == 1 {
-		size++
-	}
-
 	ch := &Chunk{
 		ID:   id,
 		Size: int(size),


### PR DESCRIPTION
Fix chunk.Size to match the definition, removing the additional padding byte which was previously present. This allows consumers to create cleaner parsing which relies on io.EOF instead of having to also check for a padding byte.

Also:
* Fix some typos.
* Clarify that IsFullyRead doesn't include the padding byte.
* Fix godoc link on README.md.

Fixes #2