### PR TITLE
 Use io instead of ioutil (deprecated) #40 

### DIFF
--- a/chunk.go
+++ b/chunk.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sync"
 )
 
@@ -122,7 +121,7 @@ func (ch *Chunk) Drain() {
 	for bytesAhead > 0 {
 		readSize := int64(bytesAhead)
 
-		if _, err := io.CopyN(ioutil.Discard, ch.R, readSize); err != nil {
+		if _, err := io.CopyN(io.Discard, ch.R, readSize); err != nil {
 			return
 		}
 		bytesAhead -= int(readSize)

--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,4 @@
 /*
-
 Package riff is package implementing a simple Resource Interchange File Format
 (RIFF) parser with basic support for sub formats such as WAV.
 The goal of this package is to give all the tools needed for a developer
@@ -10,6 +9,5 @@ of a wav file can be easily accessed (See the examples below) .
 
 For more information about RIFF:
 https://en.wikipedia.org/wiki/Resource_Interchange_File_Format
-
 */
 package riff


### PR DESCRIPTION
Deprecated since Go 1.16.